### PR TITLE
Remove dead link to msgpack-rpc-python

### DIFF
--- a/index.html.erb
+++ b/index.html.erb
@@ -185,9 +185,6 @@
       <h3>Related projects</h3>
 
       <div class="paragraphs">
-        <h4><a href="https://code.jd.com/tommybao/msgpack-rpc-python">msgpack-rpc-python</a> by WWW.JD.COM, Inc.</h4>
-        <p>msgpack-rpc is a flexible RPC implementation based on eventlet and messagepack.</p>
-
         <h4><a href="https://github.com/dotcloud/zerorpc-python">ZeroRPC</a> by DotCloud</h4>
         <p>zerorpc is a flexible RPC implementation based on zeromq and messagepack. Service APIs exposed with zerorpc are called "zeroservices".</p>
 


### PR DESCRIPTION
Link no longer works, so removed it.
https://code.jd.com/tommybao/msgpack-rpc-python