### PR TITLE
Try! functionality odd behaviour

### DIFF
--- a/js/msgpack.js
+++ b/js/msgpack.js
@@ -98,12 +98,12 @@ function encode(rv,      // @param ByteArray: result
                     // int
                     if (mix >= -32) { // negative fixnum
                         rv.push(0xe0 + mix + 32);
-                    } else if (mix > -0x80) {
+                    } else if (mix >= -0x80) {
                         rv.push(0xd0, mix + 0x100);
-                    } else if (mix > -0x8000) {
+                    } else if (mix >= -0x8000) {
                         mix += 0x10000;
                         rv.push(0xd1, mix >> 8, mix & 0xff);
-                    } else if (mix > -0x80000000) {
+                    } else if (mix >= -0x80000000) {
                         mix += 0x100000000;
                         rv.push(0xd2, mix >>> 24, (mix >> 16) & 0xff,
                                                   (mix >>  8) & 0xff, mix & 0xff);


### PR DESCRIPTION
The online Try! functionality is packing -128, -32768, -2147483648 differently than other implementation.

-128 with the online tool is encoded as "d1 ff 80" where as other implementation encode -128 to "d0 80" (i checked implementation in python, ruby,  javascript from the implementation list plus the perl implementation)
When unpacking, both "d1 ff 80" and "d0 80" are decoded as -128, however, as "d0 80" is one byte less, i guess it should be the correct implementation.
From the specification however, i was not able to confirm which one is the correct one.
