### PR TITLE
update fluentd link

### DIFF
--- a/index.html.erb
+++ b/index.html.erb
@@ -140,7 +140,7 @@
           </div>
 
           <div class="tm">
-            <a class="tmlogo" href="https://fluentd.org/" style="height:100px;margin-top:-35px;"><img src="images/fluentd.png" alt="Fluentd" width="245" height="85" /></a>
+            <a class="tmlogo" href="https://www.fluentd.org/" style="height:100px;margin-top:-35px;"><img src="images/fluentd.png" alt="Fluentd" width="245" height="85" /></a>
             <p class="tmtext">Fluentd uses MessagePack for all internal data representation. It's crazy fast because of zero-copy optimization of msgpack-ruby. Now MessagePack is an essential component of Fluentd to achieve high performance and flexibility at the same time.</p>
             <p class="tmauthor">Sadayuki Furuhashi, creator of Fluentd</p>
           </div>


### PR DESCRIPTION
https://fluentd.org/ does not redirect to their www page, so updating to a link that works.  https://www.fluentd.org/