### PR TITLE
Remove Twitter search timelines

### DIFF
--- a/index.html.erb
+++ b/index.html.erb
@@ -163,10 +163,6 @@
         </div>
       </div>
 
-      <div id="twitter">
-        <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/search?q=msgpack+OR+MessagePack+lang%3Aen" data-widget-id="343624208380735490" width="350" height="500">Tweets about "msgpack OR MessagePack"</a>
-        <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-      </div>
     </section>
     <%= '-->' if lang != 'en' %>
 


### PR DESCRIPTION
Currently loading msgpack.org shows this error in browser console:

    Embedded Search timelines have been deprecated. See https://twittercommunity.com/t/deprecating-widget-settings/102295. 

This change removes the `twitter` div.