### PR TITLE
Start page: Fix broken link

### DIFF
--- a/index.html.erb
+++ b/index.html.erb
@@ -140,7 +140,7 @@
           </div>
 
           <div class="tm">
-            <a class="tmlogo" href="https://fluentd.org/" style="height:100px;margin-top:-35px;"><img src="images/fluentd.png" alt="Fluentd" width="245" height="85" /></a>
+            <a class="tmlogo" href="https://www.fluentd.org/" style="height:100px;margin-top:-35px;"><img src="images/fluentd.png" alt="Fluentd" width="245" height="85" /></a>
             <p class="tmtext">Fluentd uses MessagePack for all internal data representation. It's crazy fast because of zero-copy optimization of msgpack-ruby. Now MessagePack is an essential component of Fluentd to achieve high performance and flexibility at the same time.</p>
             <p class="tmauthor">Sadayuki Furuhashi, creator of Fluentd</p>
           </div>

--- a/rdoc/0.4/MessagePack.html
+++ b/rdoc/0.4/MessagePack.html
@@ -266,8 +266,8 @@ static VALUE MessagePack_pack(int argc, VALUE* argv, VALUE self)
 Deserializes one object over the specified buffer.
 </p>
 <p>
-<a href="MessagePack/UnpackError.html">UnpackError</a> is throw when parse
-error is occured, the buffer is insufficient to deserialize one object or
+<a href="MessagePack/UnpackError.html">UnpackError</a> is thrown when parse
+error has occrured, the buffer is insufficient to deserialize one object or
 there are extra bytes.
 </p>
 					
@@ -308,8 +308,8 @@ Deserializes one object over the specified buffer upto <em>limit</em>
 bytes.
 </p>
 <p>
-<a href="MessagePack/UnpackError.html">UnpackError</a> is throw when parse
-error is occured, the buffer is insufficient to deserialize one object or
+<a href="MessagePack/UnpackError.html">UnpackError</a> is thrown when parse
+error has occurred, the buffer is insufficient to deserialize one object or
 there are extra bytes.
 </p>
 					

--- a/rdoc/0.4/MessagePack/Unpacker.html
+++ b/rdoc/0.4/MessagePack/Unpacker.html
@@ -371,8 +371,8 @@ Deserializes objects repeatedly. This calls <b>fill</b> method
 automatically.
 </p>
 <p>
-<a href="UnpackError.html">UnpackError</a> is throw when parse error is
-occured. This method raises exceptions that <b>fill</b> method raises.
+<a href="UnpackError.html">UnpackError</a> is thrown when parse error has
+occurred. This method raises exceptions that <b>fill</b> method raises.
 </p>
 					
 
@@ -459,8 +459,8 @@ check an object is deserialized and call <b>data</b> method if it returns
 true.
 </p>
 <p>
-<a href="UnpackError.html">UnpackError</a> is throw when parse error is
-occured.
+<a href="UnpackError.html">UnpackError</a> is thrown when parse error has
+occurred.
 </p>
 					
 
@@ -507,8 +507,8 @@ This method doesn&#8217;t use the internal buffer.
 Call <b>reset</b> method before calling this method again.
 </p>
 <p>
-<a href="UnpackError.html">UnpackError</a> is throw when parse error is
-occured.
+<a href="UnpackError.html">UnpackError</a> is thrown when parse error has
+occurred.
 </p>
 					
 


### PR DESCRIPTION
This PR fixes a broken link on the start page of the website.
It also fixes a few typos and grammar errors on the way.